### PR TITLE
Specify that index.html needs to be created in correct /web volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,9 +398,10 @@ Run a new container and map the shared volume
 docker run -it --rm -v <swarm_volume>:/web busybox
 ```
 
-Create a new `index.html` with the following command
+Create a new `index.html` in the `/web` shared volume with the following command
 
 ```
+cd /web
 echo "
 <head>
 <body>


### PR DESCRIPTION
Diff is fucked because of Windows end-line character >_< Always create a giant diff from the web UI or with a local editor:

This is the change basically:
```
cd /web
echo "
<head>
<body>
WELCOME TO DOCKERCON
</body>
</head
" > index.html
```